### PR TITLE
Add filter to root job of `build-deploy` workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,7 @@ jobs:
                       fi
 
 workflows:
-    release:
-        when:
-            matches: { pattern: '^v.+$', value: << pipeline.git.tag >> }
+    build-deploy:
         jobs:
             - build-and-test:
                   filters:
@@ -83,9 +81,16 @@ workflows:
                   type: approval
                   requires:
                       - build-and-test
+                  filters:
+                      tags:
+                          only: /^v.*/
+                      branches:
+                          ignore: /.*/
             - deploy-package:
                   requires:
                       - hold
-    build-deploy:
-        jobs:
-            - build-and-test
+                  filters:
+                      tags:
+                          only: /^v.*/
+                      branches:
+                          ignore: /.*/


### PR DESCRIPTION
Apparently, if the initial job of the workflow doesn't have a tag filter, the CircleCI just ignores any tag pushes. So it'll never match the later filters.